### PR TITLE
Use more instead of less

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM php:7-alpine
 
 MAINTAINER Pierre Prinetti <me@qrawl.net>
 
+ENV PAGER more
+
 RUN docker-php-ext-install mysqli
 
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar


### PR DESCRIPTION
wp-cli tries to use "less -r" which is not available in Alpine's less. This causes errors like:
```
ಠ_ಠ:~$ docker exec $container wp help
less: unrecognized option: r
BusyBox v1.26.2 (2017-11-23 08:40:54 GMT) multi-call binary.

Usage: less [-EIMmNSh~] [FILE]...

View FILE (or stdin) one screenful at a time

	-E	Quit once the end of a file is reached
	-I	Ignore case in all searches
	-M,-m	Display status line with line numbers
		and percentage through the file
	-N	Prefix line number to each line
	-S	Truncate long lines
	-~	Suppress ~s displayed past EOF
```